### PR TITLE
Changed byte output to not truncate leading 0's

### DIFF
--- a/TeraScanner/Core/Encryption.cs
+++ b/TeraScanner/Core/Encryption.cs
@@ -83,7 +83,7 @@ namespace TeraScanner.Core {
                 // C7 45 ?? ?? ?? ?? ??         mov [ebp-??],????????
                 if (value[0] == 0xC7 && value[1] == 0x45) {
                     for (int byteIndex = 3; byteIndex < value.Length; byteIndex++) {
-                        KEY = $"{KEY}{value[byteIndex]:X}";
+                        KEY = $"{KEY}{value[byteIndex]:X2}";
                     }
                 } else if (value[0] == 0x8B && value[1] == 0x06) {
                     // 8B 06                    mov eax,[esi]
@@ -105,7 +105,7 @@ namespace TeraScanner.Core {
                 // C7 45 ?? ?? ?? ?? ??         mov [ebp-??],????????
                 if (value[0] == 0xC7 && value[1] == 0x45) {
                     for (int byteIndex = 3; byteIndex < value.Length; byteIndex++) {
-                        IV = $"{IV}{value[byteIndex]:X}";
+                        IV = $"{IV}{value[byteIndex]:X2}";
                     }
                 } else if (value[0] == 0x8B && value[1] == 0x40) {
                     IVPart--;


### PR DESCRIPTION
Fixed a bug where bytes with leading 0's would be truncated altering the length of the Key/IV
Output Before Change
```
KEY: 80 9C 3A 12 54 32 66 4F A5 BC 4D 20 C8 2D 25 7E
IV:  4E 39 3C 76 35 12 33 D B2 F3 1B 17 DC E6 1C 3F
```
Output After Change
```
KEY: 80 9C 3A 12 54 32 66 4F A5 BC 4D 20 C8 2D 25 7E
IV:  4E 39 3C 76 35 12 33 0D B2 F3 1B 17 DC E6 1C 3F
```

*Tested on NA v88.05*